### PR TITLE
多次render问题优化

### DIFF
--- a/response.go
+++ b/response.go
@@ -1,4 +1,5 @@
 package very
+
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/gin-gonic/gin/render"
@@ -12,9 +13,14 @@ type JSONResponse struct {
 	HttpStatus int          `json:"-"`
 	Context    *gin.Context `json:"-"`
 	Data       interface{}  `json:"data"`
+	isRendered bool
 }
 
 func (c *JSONResponse) Render() {
+	if c.isRendered == true {
+		return
+	}
+	c.isRendered = true
 	c.Context.Render(c.HttpStatus, JSON{render.JSON{Data: c.Data}})
 }
 


### PR DESCRIPTION

1.AuthMiddleware如果最终返回nil（假设前面的验证都通过了），那么在业务handle里面，即使返回错误了，也会先return到调用栈（这里就是AuthMiddleware），但是由于AuthMiddleware最终返回的是nil，会将业务handle返回的response覆盖成nil，导致logMiddleware里面获取不到response，从而不记录日志

2.现在将业务层AuthMiddleware的返回结果改成ctx.response(也就是context的response，这个值会被业务Handel所修改)，但是这样子又会导致另一个问题，业务Handel 有response，此时会render一次，response被AuthMiddleware接住了返回出去，又会被middlewa   rerender一次，最终返回出去的其实是两次render的结果（两个结果合并和成一个结果）

解决办法：
在Render里面判断了一下，如果已经render了 就return